### PR TITLE
Reinstates legacy infra plugin to make saved object mappings available

### DIFF
--- a/x-pack/legacy/plugins/infra/index.ts
+++ b/x-pack/legacy/plugins/infra/index.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import { savedObjectMappings } from '../../../plugins/infra/server';
+
+export const APP_ID = 'infra';
+
+export function infra(kibana: any) {
+  return new kibana.Plugin({
+    id: APP_ID,
+    configPrefix: 'xpack.infra',
+    require: ['kibana', 'elasticsearch'],
+    uiExports: {
+      mappings: savedObjectMappings,
+    },
+  });
+}

--- a/x-pack/plugins/infra/server/index.ts
+++ b/x-pack/plugins/infra/server/index.ts
@@ -6,8 +6,9 @@
 
 import { PluginInitializerContext } from 'src/core/server';
 import { config, InfraConfig, InfraServerPlugin } from './plugin';
+import { savedObjectMappings } from './saved_objects';
 
-export { config, InfraConfig };
+export { config, InfraConfig, savedObjectMappings };
 export const APP_ID = 'infra';
 
 export function plugin(context: PluginInitializerContext) {


### PR DESCRIPTION
Until elastic/kibana#50309 merges