### PR TITLE
Initiates legacy plugin correctly with proper dummy config

### DIFF
--- a/x-pack/index.js
+++ b/x-pack/index.js
@@ -26,6 +26,7 @@ import { consoleExtensions } from './legacy/plugins/console_extensions';
 import { spaces } from './legacy/plugins/spaces';
 import { kueryAutocompleteInitializer } from './legacy/plugins/kuery_autocomplete';
 import { canvas } from './legacy/plugins/canvas';
+import { infra } from './legacy/plugins/infra';
 import { taskManager } from './legacy/plugins/task_manager';
 import { rollup } from './legacy/plugins/rollup';
 import { siem } from './legacy/plugins/siem';
@@ -67,6 +68,7 @@ module.exports = function(kibana) {
     consoleExtensions(kibana),
     indexLifecycleManagement(kibana),
     kueryAutocompleteInitializer(kibana),
+    infra(kibana),
     taskManager(kibana),
     rollup(kibana),
     transform(kibana),

--- a/x-pack/legacy/plugins/infra/index.ts
+++ b/x-pack/legacy/plugins/infra/index.ts
@@ -3,18 +3,23 @@
  * or more contributor license agreements. Licensed under the Elastic License;
  * you may not use this file except in compliance with the Elastic License.
  */
-
+import { Root } from 'joi';
 import { savedObjectMappings } from '../../../plugins/infra/server';
-
-export const APP_ID = 'infra';
 
 export function infra(kibana: any) {
   return new kibana.Plugin({
-    id: APP_ID,
+    id: 'infra',
     configPrefix: 'xpack.infra',
     require: ['kibana', 'elasticsearch'],
     uiExports: {
       mappings: savedObjectMappings,
+    },
+    config(Joi: Root) {
+      return Joi.object({
+        enabled: Joi.boolean().default(true),
+      })
+        .unknown()
+        .default();
     },
   });
 }


### PR DESCRIPTION
My previous PR (#4) didn't actually run the legacy plugin, and it didn't include the magic Joi config stuff that lets the legacy plugin run as a dummy ghost plugin. This fixes those things.

I was also able to save and load a saved view in the inventory view, as a test of the saved object situation.