### PR TITLE
Updates app ids to solve routing problem when no base path is used

### DIFF
--- a/x-pack/plugins/infra/public/pages/infrastructure/index.tsx
+++ b/x-pack/plugins/infra/public/pages/infrastructure/index.tsx
@@ -71,7 +71,7 @@ export const InfrastructurePage = ({ match }: RouteComponentProps) => {
                 title: i18n.translate('xpack.infra.homePage.metricsExplorerTabTitle', {
                   defaultMessage: 'Metrics Explorer',
                 }),
-                path: `${match.path}/metrics-explorer`,
+                path: `${match.path}/explorer`,
               },
               {
                 title: i18n.translate('xpack.infra.homePage.settingsTabTitle', {
@@ -86,7 +86,7 @@ export const InfrastructurePage = ({ match }: RouteComponentProps) => {
         <Switch>
           <Route path={`${match.path}/inventory`} component={SnapshotPage} />
           <Route
-            path={`${match.path}/metrics-explorer`}
+            path={`${match.path}/explorer`}
             render={props => (
               <WithSource>
                 {({ configuration, createDerivedIndexPattern }) => (

--- a/x-pack/plugins/infra/public/pages/link_to/redirect_to_node_detail.tsx
+++ b/x-pack/plugins/infra/public/pages/link_to/redirect_to_node_detail.tsx
@@ -27,7 +27,7 @@ export const RedirectToNodeDetail = ({
     getToFromLocation(location)
   )('');
 
-  return <Redirect to={`/infrastructure/metrics/${nodeType}/${nodeId}?${searchString}`} />;
+  return <Redirect to={`/metrics/detail/${nodeType}/${nodeId}?${searchString}`} />;
 };
 
 export const getNodeDetailUrl = ({

--- a/x-pack/plugins/infra/public/plugin.ts
+++ b/x-pack/plugins/infra/public/plugin.ts
@@ -59,13 +59,13 @@ export class Plugin
     pluginsSetup.data.autocomplete.addQuerySuggestionProvider('kuery', kueryProvider);
 
     core.application.register({
-      id: 'infra:logs',
+      id: 'logs',
       title: i18n.translate('xpack.infra.logs.pluginTitle', {
         defaultMessage: 'Logs',
       }),
       euiIconType: 'logsApp',
       order: 8001,
-      appRoute: '/app/infra/logs',
+      appRoute: '/app/logs',
       category: DEFAULT_APP_CATEGORIES.observability,
       mount: async (params: AppMountParameters) => {
         const [coreStart, pluginsStart] = await core.getStartServices();
@@ -76,13 +76,13 @@ export class Plugin
     });
 
     core.application.register({
-      id: 'infra:home',
+      id: 'metrics',
       title: i18n.translate('xpack.infra.metrics.pluginTitle', {
         defaultMessage: 'Metrics',
       }),
       euiIconType: 'metricsApp',
       order: 8000,
-      appRoute: '/app/infra/infrastructure',
+      appRoute: '/app/metrics',
       category: DEFAULT_APP_CATEGORIES.observability,
       mount: async (params: AppMountParameters) => {
         const [coreStart, pluginsStart] = await core.getStartServices();

--- a/x-pack/plugins/infra/public/routes.tsx
+++ b/x-pack/plugins/infra/public/routes.tsx
@@ -26,37 +26,33 @@ export const PageRouter: React.FC<RouterProps> = ({ history }) => {
     <Router history={history}>
       <Switch>
         {uiCapabilities?.infrastructure?.show && (
-          <RedirectWithQueryParams from="/" exact={true} to="/infrastructure/inventory" />
+          <RedirectWithQueryParams from="/" exact={true} to="/metrics/inventory" />
+        )}
+        {uiCapabilities?.infrastructure?.show && (
+          <RedirectWithQueryParams from="/metrics" exact={true} to="/metrics/inventory" />
+        )}
+        {uiCapabilities?.infrastructure?.show && (
+          <RedirectWithQueryParams from="/metrics/snapshot" exact={true} to="/metrics/inventory" />
+        )}
+        {uiCapabilities?.infrastructure?.show && (
+          <RedirectWithQueryParams from="/home" exact={true} to="/metrics/inventory" />
         )}
         {uiCapabilities?.infrastructure?.show && (
           <RedirectWithQueryParams
-            from="/infrastructure"
+            from="/metrics/metrics-explorer"
             exact={true}
-            to="/infrastructure/inventory"
+            to="/metrics/explorer"
           />
         )}
         {uiCapabilities?.infrastructure?.show && (
-          <RedirectWithQueryParams
-            from="/infrastructure/snapshot"
-            exact={true}
-            to="/infrastructure/inventory"
-          />
-        )}
-        {uiCapabilities?.infrastructure?.show && (
-          <RedirectWithQueryParams from="/home" exact={true} to="/infrastructure/inventory" />
-        )}
-        {uiCapabilities?.infrastructure?.show && (
-          <Route path="/infrastructure/metrics/:type/:node" component={MetricDetail} />
-        )}
-        {uiCapabilities?.infrastructure?.show && (
-          <RedirectWithQueryParams from="/metrics" to="/infrastructure/metrics" />
+          <Route path="/metrics/detail/:type/:node" component={MetricDetail} />
         )}
         {uiCapabilities?.logs?.show && (
           <RedirectWithQueryParams from="/logs" exact={true} to="/logs/stream" />
         )}
         {uiCapabilities?.logs?.show && <Route path="/logs" component={LogsPage} />}
         {uiCapabilities?.infrastructure?.show && (
-          <Route path="/infrastructure" component={InfrastructurePage} />
+          <Route path="/metrics" component={InfrastructurePage} />
         )}
         <Route path="/link-to" component={LinkToPage} />
         <Route component={NotFoundPage} />


### PR DESCRIPTION
## Summary

Not 100% sure on all of the redirects and routing working, but changing the app IDs _and_ the base app routes to match did unblock the problem. I think the new platform needs to give some kind of warning when those values are out of sync, or not even let them _be_ out of sync, if it's going to work like this.

